### PR TITLE
(fix) Remote backend detection

### DIFF
--- a/src/commands/scan/helpers.rs
+++ b/src/commands/scan/helpers.rs
@@ -128,8 +128,25 @@ pub fn find_module_dependencies(content: &str, current_dir: &str) -> Vec<String>
 pub fn has_backend_config(tf_files: &[fs::DirEntry]) -> bool {
     for file in tf_files {
         if let Ok(content) = fs::read_to_string(file.path()) {
-            if content.contains("backend") {
-                return true;
+            let lines: Vec<&str> = content.lines().collect();
+            let mut in_terraform_block = false;
+
+            for line in lines {
+                let trimmed_line = line.trim();
+                
+                if trimmed_line.starts_with("terraform") && trimmed_line.contains("{") {
+                    in_terraform_block = true;
+                    continue;
+                }
+
+                if in_terraform_block {
+                    if trimmed_line.starts_with("backend") && trimmed_line.contains("\"") {
+                        return true;
+                    }
+                    if trimmed_line == "}" {
+                        in_terraform_block = false;
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
# Improve Terraform Backend Configuration Detection

## Problem
The previous implementation was checking for the presence of the word "backend" in Terraform files, which could lead to false positives. The word "backend" could appear in variable names, comments, or other contexts that aren't actual backend configurations.

## Solution
Enhanced the `has_backend_config` function to properly detect Terraform backend configurations by:
- Only detecting backend configurations within a `terraform` block
- Using proper block parsing to track when we're inside a `terraform` block
- Looking for the specific pattern of a backend declaration (e.g., `backend "s3" {`)

## Example
This will now correctly identify backend configurations like:

```hcl
terraform {
  backend "s3" {
    bucket = "my-bucket"
    key    = "path/to/state"
    region = "us-east-1"
  }
}
```

While ignoring false positives like:

```hcl
variable "backend_url" {
  type     = string
  default  = "backend.example.com"
}
```


## Testing
- [x] Tested with files containing legitimate backend configurations
- [x] Tested with files containing the word "backend" in other contexts
- [x] Tested with files containing no backend configurations