### PR TITLE
(feat) Add terraform workspaces usecase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "solarboat"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "clap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solarboat"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 description = "A CLI tool for intelligent Terraform operations management with automatic dependency detection"
 license = "BSD-3-Clause"

--- a/action.yml
+++ b/action.yml
@@ -51,13 +51,10 @@ runs:
         fi
         
         if [[ "${{ inputs.command }}" == "scan" ]]; then
-          echo "🔍 Scanning for changed modules..."
           solarboat scan
         elif [[ "${{ inputs.command }}" == "plan" ]]; then
-          echo "📋 Running Terraform plan..."
           solarboat plan --output-dir ${{ inputs.plan_output_dir }} $IGNORE_WORKSPACES_ARG
         elif [[ "${{ inputs.command }}" == "apply" ]]; then
-          echo "🧱 Running Terraform apply..."
           solarboat apply --dry-run=${{ inputs.apply_dry_run }} $IGNORE_WORKSPACES_ARG
         else
           echo "❌ Invalid command: ${{ inputs.command }}"

--- a/action.yml
+++ b/action.yml
@@ -1,22 +1,25 @@
-name: 'Solarboat Action'
-description: 'GitHub Action for Infrastructure as Code management with Solarboat CLI'
+name: 'Solarboat CLI Action'
+description: 'Run Solarboat CLI commands in your GitHub Actions workflow'
 branding:
   icon: 'anchor'
   color: 'blue'
 
 inputs:
   command:
-    description: 'Command to run (scan or plan)'
-    required: false
-    default: 'scan'
+    description: 'Command to run (scan, plan, or apply)'
+    required: true
   plan_output_dir:
-    description: 'Directory for terraform plan outputs'
-    required: false
+    description: 'Directory to save Terraform plan files'
     default: 'terraform-plans'
-  apply_dry_run:
-    description: 'Enable or disable solarboat apply in dry-run mode'
     required: false
+  apply_dry_run:
+    description: 'Run apply in dry-run mode'
     default: 'true'
+    required: false
+  ignore_workspaces:
+    description: 'Comma-separated list of workspaces to ignore'
+    required: false
+    default: ''
   github_token:
     description: 'GitHub token for PR comments'
     required: true
@@ -41,15 +44,21 @@ runs:
       run: |
         echo "🚀 Running Solarboat CLI"
         
+        # Build the ignore workspaces argument if provided
+        IGNORE_WORKSPACES_ARG=""
+        if [ ! -z "${{ inputs.ignore_workspaces }}" ]; then
+          IGNORE_WORKSPACES_ARG="--ignore-workspaces ${{ inputs.ignore_workspaces }}"
+        fi
+        
         if [[ "${{ inputs.command }}" == "scan" ]]; then
           echo "🔍 Scanning for changed modules..."
           solarboat scan
         elif [[ "${{ inputs.command }}" == "plan" ]]; then
           echo "📋 Running Terraform plan..."
-          solarboat plan --output-dir ${{ inputs.plan_output_dir }}
+          solarboat plan --output-dir ${{ inputs.plan_output_dir }} $IGNORE_WORKSPACES_ARG
         elif [[ "${{ inputs.command }}" == "apply" ]]; then
           echo "🧱 Running Terraform apply..."
-          solarboat apply --dry-run=${{ inputs.apply_dry_run }}
+          solarboat apply --dry-run=${{ inputs.apply_dry_run }} $IGNORE_WORKSPACES_ARG
         else
           echo "❌ Invalid command: ${{ inputs.command }}"
           exit 1
@@ -60,7 +69,7 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: terraform-plans
-        path: ${{ inputs.output_dir }}/
+        path: ${{ inputs.plan_output_dir }}/
         retention-days: 5
 
     - name: Comment on PR

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -72,6 +72,16 @@ pub struct PlanArgs {
                     The directory will be created if it doesn't exist."
     )]
     pub output_dir: Option<String>,
+
+    #[clap(
+        long,
+        value_delimiter = ',',
+        help = "Comma-separated list of workspace names to ignore",
+        long_help = "Specify workspace names to skip during plan operation. \
+                    Multiple workspaces can be provided as comma-separated values. \
+                    Example: --ignore-workspaces dev,staging"
+    )]
+    pub ignore_workspaces: Option<Vec<String>>,
 }
 
 #[derive(Parser)]
@@ -83,4 +93,14 @@ pub struct ApplyArgs {
         long_help = "When enabled, shows what would be applied without making actual changes."
     )]
     pub dry_run: bool,
+
+    #[clap(
+        long,
+        value_delimiter = ',',
+        help = "Comma-separated list of workspace names to ignore",
+        long_help = "Specify workspace names to skip during apply operation. \
+                    Multiple workspaces can be provided as comma-separated values. \
+                    Example: --ignore-workspaces dev,staging"
+    )]
+    pub ignore_workspaces: Option<Vec<String>>,
 }

--- a/src/commands/apply/execute.rs
+++ b/src/commands/apply/execute.rs
@@ -8,15 +8,16 @@ pub fn execute(args: ApplyArgs) -> Result<(), Box<dyn std::error::Error>> {
         println!("🔍 Running in dry-run mode - no changes will be applied");
     }
 
-    let root_dir = ".";
-    match helpers::get_changed_modules(root_dir) {
+    let ignore_workspaces = args.ignore_workspaces.as_deref();
+
+    match helpers::get_changed_modules(".") {
         Ok(modules) => {
+            println!("🔍 Found {} changed files", modules.len());
             if modules.is_empty() {
-                println!("🎉 No modules to apply!");
+                println!("🎉 No modules were changed!");
                 return Ok(());
             }
-
-            println!("📦 Modules to apply:");
+            println!("📦 Changed modules...");
             println!("---------------------------------");
             for module in &modules {
                 println!("{}", module);
@@ -35,7 +36,7 @@ pub fn execute(args: ApplyArgs) -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
 
-            helpers::run_terraform_apply(&modules, args.dry_run)?;
+            helpers::run_terraform_apply(&modules, args.dry_run, ignore_workspaces)?;
             
             if args.dry_run {
                 println!("\n🔍 Dry run completed - no changes were applied");

--- a/src/commands/apply/helpers.rs
+++ b/src/commands/apply/helpers.rs
@@ -58,7 +58,7 @@ pub fn run_terraform_apply(
         let workspaces = plan_helpers::get_workspaces(module)?;
         
         if workspaces.len() <= 1 {
-            println!("  🚀 Running terraform apply for default workspace...");
+            println!("  🧱 Running terraform apply for default workspace...");
             if !run_single_apply(module)? {
                 failed_modules.push(ModuleError {
                     path: module.clone(),
@@ -80,7 +80,7 @@ pub fn run_terraform_apply(
                 println!("  🔄 Switching to workspace: {}", workspace);
                 plan_helpers::select_workspace(module, &workspace)?;
                 
-                println!("  🚀 Running terraform apply for workspace {}...", workspace);
+                println!("  🧱 Running terraform apply for workspace {}...", workspace);
                 if !run_single_apply(module)? {
                     failed_modules.push(ModuleError {
                         path: format!("{}:{}", module, workspace),

--- a/src/commands/plan/execute.rs
+++ b/src/commands/plan/execute.rs
@@ -16,6 +16,8 @@ pub fn execute(args: PlanArgs) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let root_dir = &args.path;
+    let ignore_workspaces = args.ignore_workspaces.as_deref();
+
     match helpers::get_changed_modules(root_dir) {
         Ok(modules) => {
             println!("🔍 Found {} changed files", modules.len());
@@ -28,7 +30,7 @@ pub fn execute(args: PlanArgs) -> Result<(), Box<dyn std::error::Error>> {
             for module in &modules {
                 println!("{}", module);
             }
-            helpers::run_terraform_plan(&modules, Some(output_dir))?;
+            helpers::run_terraform_plan(&modules, Some(output_dir), ignore_workspaces)?;
         }
         Err(e) => {
             eprintln!("Error getting changed modules: {}", e);

--- a/src/commands/plan/helpers.rs
+++ b/src/commands/plan/helpers.rs
@@ -22,7 +22,12 @@ pub fn get_changed_modules(root_dir: &str) -> Result<Vec<String>, String> {
     Ok(affected_modules)
 }
 
-pub fn run_terraform_plan(modules: &[String], plan_dir: Option<&str>) -> Result<(), String> {
+pub fn run_terraform_plan(
+    modules: &[String], 
+    plan_dir: Option<&str>,
+    ignore_workspaces: Option<&[String]>
+) -> Result<(), String> {
+
     let mut failed_modules = Vec::new();
 
     for module in modules {
@@ -59,6 +64,13 @@ pub fn run_terraform_plan(modules: &[String], plan_dir: Option<&str>) -> Result<
         } else {
             println!("  🌐 Found multiple workspaces: {:?}", workspaces);
             for workspace in workspaces {
+                if let Some(ignored) = ignore_workspaces {
+                    if ignored.contains(&workspace) {
+                        println!("  ⏭️  Skipping ignored workspace: {}", workspace);
+                        continue;
+                    }
+                }
+
                 println!("  🔄 Switching to workspace: {}", workspace);
                 select_workspace(module, &workspace)?;
                 

--- a/src/commands/plan/helpers.rs
+++ b/src/commands/plan/helpers.rs
@@ -45,31 +45,33 @@ pub fn run_terraform_plan(modules: &[String], plan_dir: Option<&str>) -> Result<
             continue;
         }
 
-        println!("  🚀 Running terraform plan...");
-        let mut terraform_cmd = Command::new("terraform");
-        terraform_cmd.arg("plan").current_dir(module);
-
-        if let Some(plan_dir) = plan_dir {
-            if let Some(module_name) = Path::new(module).file_name().and_then(|n| n.to_str()) {
-                let plan_file = Path::new(plan_dir).join(format!("{}.tfplan", module_name));
-                terraform_cmd.arg(format!("-out={}", plan_file.to_str().unwrap()));
+        let workspaces = get_workspaces(module)?;
+        
+        if workspaces.len() <= 1 {
+            println!("  🚀 Running terraform plan for default workspace...");
+            if !run_single_plan(module, plan_dir)? {
+                failed_modules.push(ModuleError {
+                    path: module.clone(),
+                    command: "plan".to_string(),
+                    error: "Plan failed".to_string(),
+                });
+            }
+        } else {
+            println!("  🌐 Found multiple workspaces: {:?}", workspaces);
+            for workspace in workspaces {
+                println!("  🔄 Switching to workspace: {}", workspace);
+                select_workspace(module, &workspace)?;
+                
+                println!("  🚀 Running terraform plan for workspace {}...", workspace);
+                if !run_single_plan(module, plan_dir)? {
+                    failed_modules.push(ModuleError {
+                        path: format!("{}:{}", module, workspace),
+                        command: "plan".to_string(),
+                        error: format!("Plan failed for workspace {}", workspace),
+                    });
+                }
             }
         }
-
-        let cmd_status = terraform_cmd
-            .status()
-            .map_err(|e| e.to_string())?;
-
-        if !cmd_status.success() {
-            failed_modules.push(ModuleError {
-                path: module.clone(),
-                command: "plan".to_string(),
-                error: "Plan failed".to_string(),
-            });
-            continue;
-        }
-
-        println!("  ✅ Module planned successfully");
     }
 
     if !failed_modules.is_empty() {
@@ -78,6 +80,61 @@ pub fn run_terraform_plan(modules: &[String], plan_dir: Option<&str>) -> Result<
             println!("  ❌ {}: {} failed - {}", failure.path, failure.command, failure.error);
         }
         return Err(format!("Failed to process {} module(s)", failed_modules.len()));
+    }
+
+    Ok(())
+}
+
+fn run_single_plan(module: &str, plan_dir: Option<&str>) -> Result<bool, String> {
+    let mut terraform_cmd = Command::new("terraform");
+    terraform_cmd.arg("plan").current_dir(module);
+
+    if let Some(plan_dir) = plan_dir {
+        if let Some(module_name) = Path::new(module).file_name().and_then(|n| n.to_str()) {
+            let plan_file = Path::new(plan_dir).join(format!("{}.tfplan", module_name));
+            terraform_cmd.arg(format!("-out={}", plan_file.to_str().unwrap()));
+        }
+    }
+
+    let cmd_status = terraform_cmd
+        .status()
+        .map_err(|e| e.to_string())?;
+
+    Ok(cmd_status.success())
+}
+
+pub fn get_workspaces(module_path: &str) -> Result<Vec<String>, String> {
+    let output = Command::new("terraform")
+        .arg("workspace")
+        .arg("list")
+        .current_dir(module_path)
+        .output()
+        .map_err(|e| e.to_string())?;
+
+    if !output.status.success() {
+        return Err("Failed to list workspaces".to_string());
+    }
+
+    let workspaces: Vec<String> = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(|line| line.trim().trim_start_matches('*').trim().to_string())
+        .filter(|ws| !ws.is_empty())
+        .collect();
+
+    Ok(workspaces)
+}
+
+pub fn select_workspace(module_path: &str, workspace: &str) -> Result<(), String> {
+    let output = Command::new("terraform")
+        .arg("workspace")
+        .arg("select")
+        .arg(workspace)
+        .current_dir(module_path)
+        .output()
+        .map_err(|e| e.to_string())?;
+
+    if !output.status.success() {
+        return Err(format!("Failed to select workspace {}", workspace));
     }
 
     Ok(())


### PR DESCRIPTION
# Add Workspace Management Support

## Description
This PR adds comprehensive workspace management capabilities to the Solar Boat CLI, allowing users to handle multiple Terraform workspaces efficiently and selectively skip specific workspaces during plan and apply operations.

## Features
- 🌐 Automatic workspace detection for each module
- ⚡ Individual processing of each workspace for plan/apply operations
- 🎯 New `--ignore-workspaces` flag to skip specific workspaces
- 🔄 GitHub Actions integration for workspace filtering
- 📝 Updated documentation and examples