### PR TITLE
(feat) Add Terraform installation to GitHub Actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,11 @@ runs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
 
+    - name: Install Terraform
+      uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_version: "1.7.4"
+
     - name: Install Solarboat CLI
       shell: bash
       run: |


### PR DESCRIPTION
# Add Terraform Installation to GitHub Actions Workflow

## Changes
- Added HashiCorp's official `setup-terraform` action to install Terraform
- Configured to use the latest stable version (1.7.4)
- Placed installation step before Solarboat CLI installation

## Why
- Required dependency for Solarboat to work
- Uses official HashiCorp action for reliable and secure installation
- Ensures consistent Terraform version across workflow runs

## Testing
- Workflow has been tested locally
- Installation step verifies Terraform availability automatically

## Additional Notes
- Uses HashiCorp's recommended installation method for GitHub Actions
- No additional configuration required