### PR TITLE
(feat) Plan/Apply if dependency modules has changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ assignees: ''
 
 ## Environment
 - OS: [e.g. macOS, Windows, Linux]
-- Version: [e.g. 0.4.0]
+- Version: [e.g. 0.5.0]
 - Command: [e.g. `solarboat plan --path ./terraform-modules`]
 
 ## Why This Matters

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "solarboat"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solarboat"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "A CLI tool for intelligent Terraform operations management with automatic dependency detection"
 license = "BSD-3-Clause"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ handles the operational journey so developers can focus on what they do best - w
 cargo install solarboat
 
 # Install a specific version
-cargo install solarboat --version 0.4.0
+cargo install solarboat --version 0.5.0
 ```
 
 ### Building from Source
@@ -224,12 +224,12 @@ This workflow will:
 **Basic Scan and Plan:**
 ```yaml
 - name: Scan Changes
-  uses: devqik/solarboat@v0.4.0
+  uses: devqik/solarboat@v0.5.0
   with:
     command: scan
 
 - name: Plan Changes
-  uses: devqik/solarboat@v0.4.0
+  uses: devqik/solarboat@v0.5.0
   with:
     command: plan
     plan_output_dir: my-plans
@@ -238,7 +238,7 @@ This workflow will:
 **Apply with Workspace Filtering:**
 ```yaml
 - name: Apply Changes
-  uses: devqik/solarboat@v0.4.0
+  uses: devqik/solarboat@v0.5.0
   with:
     command: apply
     ignore_workspaces: dev,staging,test
@@ -248,7 +248,7 @@ This workflow will:
 **Targeted Operations with Path Filtering:**
 ```yaml
 - name: Plan Specific Modules
-  uses: devqik/solarboat@v0.4.0
+  uses: devqik/solarboat@v0.5.0
   with:
     command: plan
     path: ./terraform-modules/production
@@ -265,7 +265,7 @@ jobs:
       
       # Run on all branches
       - name: Plan Changes
-        uses: devqik/solarboat@v0.4.0
+        uses: devqik/solarboat@v0.5.0
         with:
           command: plan
           plan_output_dir: terraform-plans
@@ -274,7 +274,7 @@ jobs:
       # Run only on main branch
       - name: Apply Changes
         if: github.ref == 'refs/heads/main'
-        uses: devqik/solarboat@v0.4.0
+        uses: devqik/solarboat@v0.5.0
         with:
           command: apply
           apply_dry_run: false


### PR DESCRIPTION
# Enhance Module Dependency Tracking for Terraform Operations

## Changes
- Enhanced the scan command to detect stateful modules that depend on changed stateless modules
- Updated `mark_module_changed` function to track the full dependency chain
- Added informative output messages when stateless module changes affect stateful modules
- Implemented duplicate prevention to avoid adding the same module multiple times

## Why
- Previously, changes to stateless modules were not properly propagating to dependent stateful modules
- This could lead to stateful modules not being planned or applied even when their dependencies changed
- The enhancement ensures that all relevant infrastructure changes are captured in Terraform operations
- Improves reliability by ensuring no dependent changes are missed

## Testing
- Tested with various module dependency scenarios
- Verified that stateful modules dependent on changed stateless modules are now properly included
- Confirmed informative output messages are displayed when dependencies are detected
- Checked that the feature works correctly with path filtering and the `--all` flag

## Additional Notes
- The output now clearly indicates when stateless module changes trigger inclusion of stateful modules
- This feature respects the existing path filtering functionality
- The implementation focuses on maintaining the existing workflow while adding dependency awareness
- No performance impact for repositories with simple module structures