### PR TITLE
(Fix) Check if the path supplied is a git repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ assignees: ''
 
 ## Environment
 - OS: [e.g. macOS, Windows, Linux]
-- Version: [e.g. 0.5.2]
+- Version: [e.g. 0.5.3]
 - Command: [e.g. `solarboat plan --path ./terraform-modules`]
 
 ## Why This Matters

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "solarboat"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "clap",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solarboat"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 description = "A CLI tool for intelligent Terraform operations management with automatic dependency detection"
 license = "BSD-3-Clause"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ handles the operational journey so developers can focus on what they do best - w
 cargo install solarboat
 
 # Install a specific version
-cargo install solarboat --version 0.5.2
+cargo install solarboat --version 0.5.3
 ```
 
 ### Building from Source
@@ -224,12 +224,12 @@ This workflow will:
 **Basic Scan and Plan:**
 ```yaml
 - name: Scan Changes
-  uses: devqik/solarboat@v0.5.2
+  uses: devqik/solarboat@v0.5.3
   with:
     command: scan
 
 - name: Plan Changes
-  uses: devqik/solarboat@v0.5.2
+  uses: devqik/solarboat@v0.5.3
   with:
     command: plan
     plan_output_dir: my-plans
@@ -238,7 +238,7 @@ This workflow will:
 **Apply with Workspace Filtering:**
 ```yaml
 - name: Apply Changes
-  uses: devqik/solarboat@v0.5.2
+  uses: devqik/solarboat@v0.5.3
   with:
     command: apply
     ignore_workspaces: dev,staging,test
@@ -248,7 +248,7 @@ This workflow will:
 **Targeted Operations with Path Filtering:**
 ```yaml
 - name: Plan Specific Modules
-  uses: devqik/solarboat@v0.5.2
+  uses: devqik/solarboat@v0.5.3
   with:
     command: plan
     path: ./terraform-modules/production
@@ -265,7 +265,7 @@ jobs:
       
       # Run on all branches
       - name: Plan Changes
-        uses: devqik/solarboat@v0.5.2
+        uses: devqik/solarboat@v0.5.3
         with:
           command: plan
           plan_output_dir: terraform-plans
@@ -274,7 +274,7 @@ jobs:
       # Run only on main branch
       - name: Apply Changes
         if: github.ref == 'refs/heads/main'
-        uses: devqik/solarboat@v0.5.2
+        uses: devqik/solarboat@v0.5.3
         with:
           command: apply
           apply_dry_run: false

--- a/src/commands/scan/execute.rs
+++ b/src/commands/scan/execute.rs
@@ -2,43 +2,60 @@ use crate::cli::ScanArgs;
 use super::helpers;
 use std::io;
 use std::collections::HashSet;
+use std::process::Command;
 
 pub fn execute(args: ScanArgs) -> Result<(), Box<dyn std::error::Error>> {
-    match helpers::get_changed_modules(&args.path, args.all) {
-        Ok(modules) => {
-            // Use a HashSet to deduplicate modules based on their names
-            let mut unique_module_names = HashSet::new();
-            let unique_modules: Vec<_> = modules.iter()
-                .filter(|module| {
-                    let module_name = module.split('/').last().unwrap_or(module);
-                    unique_module_names.insert(module_name.to_string())
-                })
-                .collect();
-            
-            if args.all {
-                println!("🔍 Found {} stateful modules", unique_modules.len());
-                println!("📦 All stateful modules will be scanned...");
-            } else {
-                if unique_modules.is_empty() {
-                    println!("🎉 No modules were changed!");
-                    return Ok(());
+    // Check if the specified path is a git repository
+    let git_check = Command::new("git")
+        .args(&["rev-parse", "--is-inside-work-tree"])
+        .current_dir(&args.path)
+        .output();
+
+    match git_check {
+        Ok(output) if output.status.success() => {
+            // We're in a git repository, proceed with scanning
+            match helpers::get_changed_modules(&args.path, args.all) {
+                Ok(modules) => {
+                    // Use a HashSet to deduplicate modules based on their names
+                    let mut unique_module_names = HashSet::new();
+                    let unique_modules: Vec<_> = modules.iter()
+                        .filter(|module| {
+                            let module_name = module.split('/').last().unwrap_or(module);
+                            unique_module_names.insert(module_name.to_string())
+                        })
+                        .collect();
+                    
+                    if args.all {
+                        println!("🔍 Found {} stateful modules", unique_modules.len());
+                        println!("📦 All stateful modules will be scanned...");
+                    } else {
+                        if unique_modules.is_empty() {
+                            println!("🎉 No modules were changed!");
+                            return Ok(());
+                        }
+                        println!("📦 Found {} changed modules:", unique_modules.len());
+                    }
+                    println!("---------------------------------");
+                    
+                    // Sort module names for consistent output
+                    let mut sorted_module_names: Vec<_> = unique_module_names.into_iter().collect();
+                    sorted_module_names.sort();
+                    
+                    for module_name in sorted_module_names {
+                        println!("  • {}", module_name);
+                    }
+                    println!("---------------------------------");
                 }
-                println!("📦 Found {} changed modules:", unique_modules.len());
+                Err(e) => {
+                    eprintln!("Error getting changed modules: {}", e);
+                    return Err(Box::new(io::Error::new(io::ErrorKind::Other, e)));
+                }
             }
-            println!("---------------------------------");
-            
-            // Sort module names for consistent output
-            let mut sorted_module_names: Vec<_> = unique_module_names.into_iter().collect();
-            sorted_module_names.sort();
-            
-            for module_name in sorted_module_names {
-                println!("  • {}", module_name);
-            }
-            println!("---------------------------------");
         }
-        Err(e) => {
-            eprintln!("Error getting changed modules: {}", e);
-            return Err(Box::new(io::Error::new(io::ErrorKind::Other, e)));
+        _ => {
+            eprintln!("❌ Error: Path '{}' is not a git repository", args.path);
+            eprintln!("Please specify a path that is within a git repository.");
+            return Err(Box::new(io::Error::new(io::ErrorKind::Other, "Not a git repository")));
         }
     }
     Ok(())


### PR DESCRIPTION
# Add Git Repository Check to Scan Command

## Changes
- Added git repository validation check to the scan command
- Modified the check to validate the specified path is within a git repository
- Updated error messages to be more descriptive and user-friendly
- Added proper error handling for non-git repository paths

## Why
- The scan command requires git functionality to detect changed modules
- Previously, the command would fail with unclear errors when run outside a git repository
- This change provides better user experience by failing fast with clear error messages
- Ensures the command is only run in valid git repository contexts

## Testing
- Tested the command in the following scenarios:
  - Running in a valid git repository (success case)
  - Running in a non-git directory (error case)
  - Running with a specific path that is not in a git repository (error case)
  - Running with a specific path that is in a git repository (success case)
- Verified error messages are clear and helpful
- Confirmed existing functionality works as expected when in a valid git repository

## Additional Notes
- This change improves the robustness of the scan command
- The error messages are consistent with the CLI's existing style
- No breaking changes to the existing API or functionality
- Future improvements could include:
  - Adding a `--no-git-check` flag for advanced users
  - Supporting git submodule paths
  - Adding more detailed git repository validation