### PR TITLE
(Feat) Change default git branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "solarboat"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solarboat"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "A CLI tool for intelligent Terraform operations management with automatic dependency detection"
 license = "BSD-3-Clause"

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ handles the operational journey so developers can focus on what they do best - w
 cargo install solarboat
 
 # Install a specific version
-cargo install solarboat --version 0.7.0
+cargo install solarboat --version 0.7.1
 ```
 
 ### Building from Source
@@ -75,6 +75,10 @@ solarboat scan
 # Scan modules in a specific directory
 solarboat scan --path ./terraform-modules
 
+# Scan with custom default branch
+solarboat scan --default-branch master
+solarboat scan --default-branch develop
+
 # Plan Terraform changes
 solarboat plan
 
@@ -90,6 +94,10 @@ solarboat plan --ignore-workspaces dev,staging
 # Process all stateful modules regardless of changes
 solarboat plan --all
 
+# Plan with custom default branch
+solarboat plan --default-branch master
+solarboat plan --default-branch develop
+
 # Apply Terraform changes (dry-run mode by default)
 solarboat apply
 
@@ -101,6 +109,10 @@ solarboat apply --ignore-workspaces prod,staging
 
 # Process all stateful modules regardless of changes
 solarboat apply --all
+
+# Apply with custom default branch
+solarboat apply --default-branch master
+solarboat apply --default-branch develop
 
 # Watch background Terraform operations with real-time output
 solarboat plan --watch
@@ -117,12 +129,30 @@ solarboat apply --dry-run=false --watch --ignore-workspaces dev,staging
 
 The scan command analyzes your repository for changed Terraform modules and their dependencies. It:
 
-- Detects modified `.tf` files
+- Detects modified `.tf` files by comparing against a default branch
 - Builds a dependency graph
 - Identifies affected modules
 - Filters modules based on the specified path
 - Does not generate any plans or make changes
 - Can process all stateful modules with `--all` flag
+- Supports custom default branch names with `--default-branch`
+
+**Default Branch Configuration:**
+
+By default, Solar Boat compares changes against the `main` branch. You can specify a different default branch:
+
+```bash
+# Use 'master' as the default branch
+solarboat scan --default-branch master
+
+# Use 'develop' as the default branch
+solarboat scan --default-branch develop
+
+# Use 'main' (default)
+solarboat scan --default-branch main
+```
+
+This is useful for repositories that use different default branch names (e.g., `master` instead of `main`).
 
 #### Plan
 
@@ -137,6 +167,7 @@ The plan command generates Terraform plans for changed modules. It:
 - Filters modules based on the specified path
 - Can process all stateful modules with `--all` flag
 - Saves plans as Markdown files for better readability
+- Supports custom default branch names with `--default-branch`
 
 #### Apply
 
@@ -150,6 +181,7 @@ The apply command implements the changes to your infrastructure. It:
 - Shows real-time progress
 - Filters modules based on the specified path
 - Can process all stateful modules with `--all` flag
+- Supports custom default branch names with `--default-branch`
 
 ### Background Operations with `--watch`
 
@@ -399,14 +431,14 @@ jobs:
 
       - name: Scan for Changes
         if: github.event_name == 'pull_request'
-        uses: devqik/solarboat@v0.7.0
+        uses: devqik/solarboat@v0.7.1
         with:
           command: scan
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Plan Infrastructure Changes
         if: github.event_name == 'pull_request'
-        uses: devqik/solarboat@v0.7.0
+        uses: devqik/solarboat@v0.7.1
         with:
           command: plan
           output_dir: terraform-plans
@@ -414,7 +446,7 @@ jobs:
 
       - name: Apply Infrastructure Changes
         if: github.ref == 'refs/heads/main'
-        uses: devqik/solarboat@v0.7.0
+        uses: devqik/solarboat@v0.7.1
         with:
           command: apply
           apply_dry_run: false # Set to true for dry-run mode
@@ -439,7 +471,8 @@ This workflow will:
 | `path`              | Root directory to scan for Terraform modules       | No       | `'.'`             |
 | `all`               | Process all stateful modules regardless of changes | No       | `false`           |
 | `watch`             | Enable real-time Terraform output display          | No       | `false`           |
-| `parallel`          | The number of processes to run in parallel         | No       | `false`           |
+| `parallel`          | The number of processes to run in parallel         | No       | `1`               |
+| `default-branch`    | Change the default git branch                      | No       | `main`            |
 
 #### Workflow Examples
 
@@ -447,12 +480,12 @@ This workflow will:
 
 ```yaml
 - name: Scan Changes
-  uses: devqik/solarboat@v0.7.0
+  uses: devqik/solarboat@v0.7.1
   with:
     command: scan
 
 - name: Plan Changes
-  uses: devqik/solarboat@v0.7.0
+  uses: devqik/solarboat@v0.7.1
   with:
     command: plan
     plan_output_dir: my-plans
@@ -462,7 +495,7 @@ This workflow will:
 
 ```yaml
 - name: Apply Changes
-  uses: devqik/solarboat@v0.7.0
+  uses: devqik/solarboat@v0.7.1
   with:
     command: apply
     ignore_workspaces: dev,staging,test
@@ -473,7 +506,7 @@ This workflow will:
 
 ```yaml
 - name: Plan Specific Modules
-  uses: devqik/solarboat@v0.7.0
+  uses: devqik/solarboat@v0.7.1
   with:
     command: plan
     path: ./terraform-modules/production
@@ -484,7 +517,7 @@ This workflow will:
 
 ```yaml
 - name: Plan with Real-time Output
-  uses: devqik/solarboat@v0.7.0
+  uses: devqik/solarboat@v0.7.1
   with:
     command: plan
     watch: true
@@ -502,7 +535,7 @@ jobs:
 
       # Run on all branches
       - name: Plan Changes
-        uses: devqik/solarboat@v0.7.0
+        uses: devqik/solarboat@v0.7.1
         with:
           command: plan
           plan_output_dir: terraform-plans
@@ -511,7 +544,7 @@ jobs:
       # Run only on main branch
       - name: Apply Changes
         if: github.ref == 'refs/heads/main'
-        uses: devqik/solarboat@v0.7.0
+        uses: devqik/solarboat@v0.7.1
         with:
           command: apply
           apply_dry_run: false

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -75,6 +75,16 @@ pub struct ScanArgs {
                     in the specified directory, regardless of whether they have been changed."
     )]
     pub all: bool,
+
+    #[clap(
+        long,
+        default_value = "main",
+        help = "Default branch to compare against for changes",
+        long_help = "Specify the default branch name to compare against when detecting changes. \
+                    This is used to determine which modules have been modified since the last \
+                    merge with the default branch. Default is 'main'."
+    )]
+    pub default_branch: String,
 }
 
 #[derive(Parser)]
@@ -144,6 +154,16 @@ pub struct PlanArgs {
                     Default is 1 (sequential processing)."
     )]
     pub parallel: u32,
+
+    #[clap(
+        long,
+        default_value = "main",
+        help = "Default branch to compare against for changes",
+        long_help = "Specify the default branch name to compare against when detecting changes. \
+                    This is used to determine which modules have been modified since the last \
+                    merge with the default branch. Default is 'main'."
+    )]
+    pub default_branch: String,
 }
 
 #[derive(Parser)]
@@ -212,4 +232,14 @@ pub struct ApplyArgs {
                     Default is 1 (sequential processing)."
     )]
     pub parallel: u32,
+
+    #[clap(
+        long,
+        default_value = "main",
+        help = "Default branch to compare against for changes",
+        long_help = "Specify the default branch name to compare against when detecting changes. \
+                    This is used to determine which modules have been modified since the last \
+                    merge with the default branch. Default is 'main'."
+    )]
+    pub default_branch: String,
 }

--- a/src/commands/apply/execute.rs
+++ b/src/commands/apply/execute.rs
@@ -11,7 +11,7 @@ pub fn execute(args: ApplyArgs, settings: &Settings) -> anyhow::Result<()> {
         println!("⚠️  Running in APPLY mode - changes will be applied!");
     }
 
-    match helpers::get_changed_modules(&args.path, args.all) {
+    match helpers::get_changed_modules(&args.path, args.all, &args.default_branch) {
         Ok(modules) => {
             if args.all {
                 println!("🔍 Found {} stateful modules", modules.len());

--- a/src/commands/apply/helpers.rs
+++ b/src/commands/apply/helpers.rs
@@ -11,9 +11,9 @@ pub struct ModuleError {
     error: String,
 }
 
-pub fn get_changed_modules(root_dir: &str, force: bool) -> Result<Vec<String>, String> {
+pub fn get_changed_modules(root_dir: &str, force: bool, default_branch: &str) -> Result<Vec<String>, String> {
     // Use the scan helpers' get_changed_modules function directly
-    helpers::get_changed_modules(root_dir, force)
+    helpers::get_changed_modules(root_dir, force, default_branch)
 }
 
 pub fn run_terraform_apply(

--- a/src/commands/plan/execute.rs
+++ b/src/commands/plan/execute.rs
@@ -15,7 +15,7 @@ pub fn execute(args: PlanArgs, settings: &Settings) -> anyhow::Result<()> {
         fs::create_dir_all(output_dir)?;
     }
 
-    match helpers::get_changed_modules(&args.path, args.all) {
+    match helpers::get_changed_modules(&args.path, args.all, &args.default_branch) {
         Ok(modules) => {
             if args.all {
                 println!("🔍 Found {} stateful modules", modules.len());

--- a/src/commands/plan/helpers.rs
+++ b/src/commands/plan/helpers.rs
@@ -11,9 +11,9 @@ pub struct ModuleError {
     error: String,
 }
 
-pub fn get_changed_modules(root_dir: &str, force: bool) -> Result<Vec<String>, String> {
+pub fn get_changed_modules(root_dir: &str, force: bool, default_branch: &str) -> Result<Vec<String>, String> {
     // Use the scan helpers' get_changed_modules function directly
-    helpers::get_changed_modules(root_dir, force)
+    helpers::get_changed_modules(root_dir, force, default_branch)
 }
 
 pub fn run_terraform_plan(

--- a/src/commands/scan/execute.rs
+++ b/src/commands/scan/execute.rs
@@ -14,7 +14,7 @@ pub fn execute(args: ScanArgs, _settings: &Settings) -> anyhow::Result<()> {
     match git_check {
         Ok(output) if output.status.success() => {
             // We're in a git repository, proceed with scanning
-            match helpers::get_changed_modules(&args.path, args.all) {
+            match helpers::get_changed_modules(&args.path, args.all, &args.default_branch) {
                 Ok(modules) => {
                     // Use a HashSet to deduplicate modules based on their names
                     let mut unique_module_names = HashSet::new();


### PR DESCRIPTION
# PR: Add Configurable Default Branch Support

## 🎯 Overview

This PR adds support for configurable default branch names across all Solar Boat CLI commands. Users can now specify which branch to compare against when detecting changes, making the tool more flexible for repositories that use different default branch names (e.g., `master` instead of `main`).

## ✨ Features Added

### New `--default-branch` Argument

- **Added to all commands**: `scan`, `plan`, and `apply`
- **Default value**: `"main"` (maintains backward compatibility)
- **Customizable**: Users can specify any branch name
- **Consistent behavior**: All commands use the same branch comparison logic

### Enhanced Git Change Detection

- Updated `get_git_changed_files()` to accept a `default_branch` parameter
- Modified merge-base comparison logic to use the specified branch
- Maintains fallback behavior for repositories without remote tracking

## 🔧 Technical Changes

### CLI Arguments (`src/cli/args.rs`)

- Added `default_branch: String` field to `ScanArgs`, `PlanArgs`, and `ApplyArgs`
- Set default value to `"main"`
- Added comprehensive help text with examples

### Scan Module (`src/commands/scan/`)

- Updated `get_changed_modules()` function signature to accept `default_branch` parameter
- Modified `get_git_changed_files()` to use the specified branch for comparisons
- Updated scan command execution to pass the branch parameter

### Plan & Apply Modules (`src/commands/plan/`, `src/commands/apply/`)

- Updated helper functions to accept and pass through the default branch parameter
- Modified command execution to use the new parameter

### Documentation (`README.md`)

- Added detailed documentation for the new feature
- Included usage examples for different branch names
- Updated command descriptions to mention the new capability

## 📖 Usage Examples

```bash
# Use default 'main' branch (existing behavior)
solarboat scan
solarboat plan
solarboat apply

# Use 'master' branch
solarboat scan --default-branch master
solarboat plan --default-branch master
solarboat apply --default-branch master

# Use 'develop' branch
solarboat scan --default-branch develop
solarboat plan --default-branch develop
solarboat apply --default-branch develop
```

## 🧪 Testing

- ✅ All existing tests pass
- ✅ CLI help system correctly displays the new argument
- ✅ Functionality tested with different branch names
- ✅ Backward compatibility verified (defaults to `main`)

## 🔄 Backward Compatibility

- **Fully backward compatible**: Defaults to `"main"` branch
- **No breaking changes**: Existing workflows continue to work unchanged
- **Optional feature**: Users only need to specify the argument if they want different behavior

## 🎯 Benefits

1. **Repository Flexibility**: Works with repositories using different default branch names
2. **Team Collaboration**: Supports various Git workflows and branch naming conventions
3. **CI/CD Integration**: Enables proper change detection in different branch strategies
4. **User Experience**: Clear, well-documented feature with sensible defaults

## 📋 Checklist

- [x] Add `--default-branch` argument to all commands
- [x] Update function signatures to accept branch parameter
- [x] Implement branch-aware git change detection
- [x] Update documentation with examples
- [x] Test backward compatibility
- [x] Verify CLI help output
- [x] Run full test suite
- [x] Update version to 0.7.1

## 🔗 Related Issues

- Addresses need for flexible default branch support
- Improves compatibility with different Git workflows
- Enhances user experience for teams with custom branch naming

---

**Version**: 0.7.1  
**Type**: Feature  
**Breaking Changes**: None