### PR TITLE
(Refactor) Default branch handling and scan command

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -397,7 +397,7 @@ If your module-specific settings (like `ignore_workspaces` or `workspace_var_fil
 - Use relative paths like `"terraform/projects/webapp"` rather than absolute paths in your configuration
 - Check that the module exists and contains `.tf` files
 
-**Note**: As of version 0.8.4+, path normalization automatically handles absolute vs relative path mismatches.
+**Note**: As of version 0.8.5+, path normalization automatically handles absolute vs relative path mismatches.
 
 ### Unexpected Variable Files
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "solarboat"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solarboat"
-version = "0.8.4"
+version = "0.8.5"
 edition = "2021"
 description = "A CLI tool for intelligent Terraform operations management with automatic dependency detection"
 license = "BSD-3-Clause"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Inspired by the Ancient Egyptian solar boats that carried Pharaohs through their
 ```bash
 cargo install solarboat
 # Or install a specific version
-cargo install solarboat --version 0.8.4
+cargo install solarboat --version 0.8.5
 ```
 
 **From Release Binaries:**
@@ -226,13 +226,13 @@ jobs:
           fetch-depth: 0
 
       - name: Scan for Changes
-        uses: devqik/solarboat@v0.8.4
+        uses: devqik/solarboat@v0.8.5
         with:
           command: scan
 
       - name: Plan Infrastructure
         if: github.event_name == 'pull_request'
-        uses: devqik/solarboat@v0.8.4
+        uses: devqik/solarboat@v0.8.5
         with:
           command: plan
           output-dir: terraform-plans
@@ -241,7 +241,7 @@ jobs:
 
       - name: Apply Changes
         if: github.ref == 'refs/heads/main'
-        uses: devqik/solarboat@v0.8.4
+        uses: devqik/solarboat@v0.8.5
         with:
           command: apply
           apply-dryrun: false
@@ -271,12 +271,12 @@ jobs:
 
       - name: Plan Infrastructure Changes
         if: github.event_name == 'pull_request'
-        uses: devqik/solarboat@v0.8.4
+        uses: devqik/solarboat@v0.8.5
         with:
           command: plan
           config: ./infrastructure/solarboat.json
           terraform-version: "1.8.0"
-          solarboat-version: "v0.8.4"
+          solarboat-version: "v0.8.5"
           parallel: 3
           ignore-workspaces: dev,test
           output-dir: terraform-plans
@@ -284,7 +284,7 @@ jobs:
 
       - name: Apply Infrastructure Changes
         if: github.ref == 'refs/heads/main'
-        uses: devqik/solarboat@v0.8.4
+        uses: devqik/solarboat@v0.8.5
         with:
           command: apply
           apply-dryrun: false
@@ -329,7 +329,7 @@ jobs:
 ```yaml
 - name: Plan Infrastructure
   id: plan
-  uses: devqik/solarboat@v0.8.4
+  uses: devqik/solarboat@v0.8.5
   with:
     command: plan
     github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -345,14 +345,14 @@ jobs:
 
 ```yaml
 - name: Plan Staging
-  uses: devqik/solarboat@v0.8.4
+  uses: devqik/solarboat@v0.8.5
   with:
     command: plan
     config: ./configs/solarboat.staging.json
     path: ./environments/staging
 
 - name: Plan Production
-  uses: devqik/solarboat@v0.8.4
+  uses: devqik/solarboat@v0.8.5
   with:
     command: plan
     config: ./configs/solarboat.prod.json
@@ -364,7 +364,7 @@ jobs:
 
 ```yaml
 - name: Apply with Error Handling
-  uses: devqik/solarboat@v0.8.4
+  uses: devqik/solarboat@v0.8.5
   with:
     command: apply
     apply-dryrun: false

--- a/src/commands/apply/execute.rs
+++ b/src/commands/apply/execute.rs
@@ -24,9 +24,9 @@ pub fn execute(args: ApplyArgs, settings: &Settings) -> anyhow::Result<()> {
             eprintln!("Warning: Invalid value for --watch: '{}'. Using default (true).", value);
             true
         }),
-        None => false, // Flag not provided
+        None => false,
     };
-    
+
     if dry_run {
         println!("🔍 Running in dry-run mode (default) - no changes will be applied");
     } else {

--- a/src/commands/apply/helpers.rs
+++ b/src/commands/apply/helpers.rs
@@ -1,4 +1,4 @@
-use crate::commands::scan::helpers;
+use crate::utils::scan_utils;
 use crate::commands::plan::helpers as plan_helpers;
 use crate::utils::parallel_processor::ParallelProcessor;
 use crate::utils::terraform_operations::{TerraformOperation, OperationType, ensure_module_initialized};
@@ -13,8 +13,7 @@ pub struct ModuleError {
 }
 
 pub fn get_changed_modules(root_dir: &str, force: bool, default_branch: &str) -> Result<Vec<String>, String> {
-    // Use the scan helpers' get_changed_modules function directly
-    helpers::get_changed_modules(root_dir, force, default_branch)
+    scan_utils::get_changed_modules(root_dir, force, default_branch)
 }
 
 pub fn run_terraform_apply(

--- a/src/commands/plan/execute.rs
+++ b/src/commands/plan/execute.rs
@@ -11,7 +11,7 @@ pub fn execute(args: PlanArgs, settings: &Settings) -> anyhow::Result<()> {
             eprintln!("Warning: Invalid value for --all: '{}'. Using default (true).", value);
             true
         }),
-        None => false, // Flag not provided
+        None => false,
     };
     
     let watch = match &args.watch {
@@ -19,9 +19,9 @@ pub fn execute(args: PlanArgs, settings: &Settings) -> anyhow::Result<()> {
             eprintln!("Warning: Invalid value for --watch: '{}'. Using default (true).", value);
             true
         }),
-        None => false, // Flag not provided
+        None => false,
     };
-    
+
     let output_dir = args.output_dir.as_deref().unwrap_or("terraform-plans");
     let output_path = Path::new(output_dir);
 

--- a/src/commands/plan/helpers.rs
+++ b/src/commands/plan/helpers.rs
@@ -1,4 +1,4 @@
-use crate::commands::scan::helpers;
+use crate::utils::scan_utils;
 use crate::config::ConfigResolver;
 use crate::utils::parallel_processor::ParallelProcessor;
 use crate::utils::terraform_operations::{TerraformOperation, OperationType, ensure_module_initialized};
@@ -12,8 +12,7 @@ pub struct ModuleError {
 }
 
 pub fn get_changed_modules(root_dir: &str, force: bool, default_branch: &str) -> Result<Vec<String>, String> {
-    // Use the scan helpers' get_changed_modules function directly
-    helpers::get_changed_modules(root_dir, force, default_branch)
+    scan_utils::get_changed_modules(root_dir, force, default_branch)
 }
 
 pub fn run_terraform_plan(

--- a/src/commands/scan/execute.rs
+++ b/src/commands/scan/execute.rs
@@ -1,6 +1,6 @@
 use crate::cli::ScanArgs;
 use crate::config::Settings;
-use super::helpers;
+use crate::utils::scan_utils;
 use std::collections::HashSet;
 use std::process::Command;
 
@@ -13,7 +13,7 @@ pub fn execute(args: ScanArgs, _settings: &Settings) -> anyhow::Result<()> {
         }),
         None => false, // Flag not provided
     };
-    
+
     // Check if the specified path is a git repository
     let git_check = Command::new("git")
         .args(&["rev-parse", "--is-inside-work-tree"])
@@ -23,7 +23,7 @@ pub fn execute(args: ScanArgs, _settings: &Settings) -> anyhow::Result<()> {
     match git_check {
         Ok(output) if output.status.success() => {
             // We're in a git repository, proceed with scanning
-            match helpers::get_changed_modules(&args.path, all, &args.default_branch) {
+            match scan_utils::get_changed_modules(&args.path, all, &args.default_branch) {
                 Ok(modules) => {
                     // Use a HashSet to deduplicate modules based on their names
                     let mut unique_module_names = HashSet::new();

--- a/src/commands/scan/mod.rs
+++ b/src/commands/scan/mod.rs
@@ -1,4 +1,3 @@
 mod execute;
-pub mod helpers;
 
 pub use execute::execute;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,3 +4,4 @@ pub mod parallel_processor;
 pub mod terraform_background;
 pub mod terraform_operations;
 pub mod display_utils;
+pub mod scan_utils;


### PR DESCRIPTION
# Fix: Enhanced Main Branch Detection + Code Refactor

## Summary

This PR fixes a critical bug where Solarboat couldn't detect changes when merging to the main branch, and refactors scan functions to improve code organization.

## 🐛 Bug Fix: Main Branch Detection

**Problem**: When merging changes to main, Solarboat reported "No modules were changed!" because it compared main branch with itself.

**Solution**: Enhanced detection that automatically:
- Detects when on main branch
- Uses recent commits, uncommitted changes, and reference points to find changes
- Provides helpful messages when no changes detected

## 🔧 Refactor: Move Scan Functions to Utils

- Moved scan functions from `src/commands/scan/helpers.rs` to `src/utils/scan_utils.rs`
- Updated all commands to use the new utils module
- Improved code organization and maintainability

## Changes

### New Files
- `src/utils/scan_utils.rs` - All scan functions including enhanced main branch detection

### Removed Files
- `src/commands/scan/helpers.rs` - Functions moved to utils

### Modified Files
- Updated module imports in scan, plan, and apply commands
- Added scan_utils to utils module

## Testing

✅ **Before**: Main branch showed "No modules were changed!"  
✅ **After**: Main branch correctly detects recent changes and affected modules

```bash
# Main branch now works correctly
solarboat scan
# ✅ Detects changes and shows affected modules
```

## Impact

- **Fixes CI/CD Issue**: Resolves the main branch detection problem
- **Better Code Organization**: Scan functions now in utils folder
- **No Breaking Changes**: All existing functionality preserved

---

**Type**: Bug Fix + Refactor  
**Breaking Changes**: None